### PR TITLE
Install packages to help Pylint check PySide6 code

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -81,6 +81,13 @@ jobs:
       - name: Install Python deps for lint checks
         run: python -m pip install -r requirements-lint.txt
 
+      - name: Install missing packages to help Pylint check PySide6 imports properly
+        # https://github.com/pylint-dev/pylint/issues/3729#issuecomment-1398167133 did not solve the issue.
+        # Now trying with packages listed in https://github.com/pylint-dev/pylint/issues/3729#issuecomment-2779318606
+        run: |
+          sudo apt update 
+          sudo apt install -y libgl1 libegl1
+
       - name: Run Pylint checks
         run: python -m pylint $(git ls-files '*.py')
         # Mark this check optional for now, in case it starts out failing.


### PR DESCRIPTION
Pylint has trouble introspecting PySide6 imports due to its use of C extensions:

> app.py:22:0: E0611: No name 'QApplication' in module 'PySide6.QtWidgets' (no-name-in-module)
> app.py:22:0: E0611: No name 'QMainWindow' in module 'PySide6.QtWidgets' (no-name-in-module)
> app.py:22:0: E0611: No name 'QFileDialog' in module 'PySide6.QtWidgets' (no-name-in-module)
> app.py:22:0: E0611: No name 'QLabel' in module 'PySide6.QtWidgets' (no-name-in-module)
> app.py:22:0: E0611: No name 'QWidget' in module 'PySide6.QtWidgets' (no-name-in-module)
> app.py:22:0: E0611: No name 'QVBoxLayout' in module 'PySide6.QtWidgets' (no-name-in-module)
> app.py:22:0: E0611: No name 'QHBoxLayout' in module 'PySide6.QtWidgets' (no-name-in-module)
> app.py:22:0: E0611: No name 'QPushButton' in module 'PySide6.QtWidgets' (no-name-in-module)
> app.py:22:0: E0611: No name 'QScrollArea' in module 'PySide6.QtWidgets' (no-name-in-module)
> app.py:26:0: E0611: No name 'QPixmap' in module 'PySide6.QtGui' (no-name-in-module)
> app.py:26:0: E0611: No name 'QPainter' in module 'PySide6.QtGui' (no-name-in-module)
> app.py:26:0: E0611: No name 'QPen' in module 'PySide6.QtGui' (no-name-in-module)
> app.py:26:0: E0611: No name 'QColor' in module 'PySide6.QtGui' (no-name-in-module)
> app.py:26:0: E0611: No name 'QFont' in module 'PySide6.QtGui' (no-name-in-module)
> app.py:27:0: E0611: No name 'Qt' in module 'PySide6.QtCore' (no-name-in-module)
> app.py:27:0: E0611: No name 'QRect' in module 'PySide6.QtCore' (no-name-in-module)
> app.py:27:0: E0611: No name 'QPoint' in module 'PySide6.QtCore' (no-name-in-module)
> app.py:27:0: E0611: No name 'QSize' in module 'PySide6.QtCore' (no-name-in-module)