### PR TITLE
Fix deprecated `.pos()` -> `.position().toPoint()`

### DIFF
--- a/app.py
+++ b/app.py
@@ -56,7 +56,7 @@ class PDFViewerLabel(QLabel):
     def mousePressEvent(self, event): # pylint: disable=invalid-name
         """Handle mouse click to start the selection."""
         if event.button() == Qt.LeftButton:
-            self.start_point = event.pos()
+            self.start_point = event.position().toPoint()
             self.selection_rect = QRect(self.start_point, QSize())
             self.is_selecting = True
             self.update()
@@ -64,7 +64,7 @@ class PDFViewerLabel(QLabel):
     def mouseMoveEvent(self, event): # pylint: disable=invalid-name
         """Handle mouse drag while selection is in progress."""
         if self.is_selecting:
-            self.end_point = event.pos()
+            self.end_point = event.position().toPoint()
             self.selection_rect = QRect(self.start_point, self.end_point).normalized()
             self.update() # Trigger a repaint
 


### PR DESCRIPTION
Previously, we got these messages in the terminal:

> DeprecationWarning: Function: 'QMouseEvent.pos() const' is marked as
> deprecated, please check the documentation for more information.

https://doc.qt.io/qt-6/qmouseevent-obsolete.html#pos says:

> This function is deprecated since 6.0. We strongly advise against using it in
> new code.
>
> Use position() instead.

However, `position()` returns `QPointF` while `pos()` returned `QPoint`, so to keep compatibility with our existing code, we need to convert `QPointF` to `QPoint` via `QPointF::toPoint()`: https://doc.qt.io/qt-6/qpointf.html#toPoint

This change cleans up the output in the terminal at app startup.